### PR TITLE
Ignore case for login button selector

### DIFF
--- a/tiss-autologin.js
+++ b/tiss-autologin.js
@@ -27,7 +27,7 @@ var PASSWORD = null;
 })();
 
 function attemptTuwelLogin() {
-    var button = document.querySelector('#login_navbar_buttons a[title="TU Account Login"]');
+    var button = document.querySelector('#login_navbar_buttons a[title="TU Account Login" i]');
 
     if (button !== null) {
         console.log('Found login button, logging in');


### PR DESCRIPTION
The English text of the login button in TUWEL is "TU Account login". Due to the lowercase "login" in the English version the JQuery selector doesn't select it. 
Therefore I added the "ignore-case" flag to the JQuery selector.